### PR TITLE
Clearly instruct to delete and insert new history for feature replication

### DIFF
--- a/markdown/datahub/use-cases/feature-replication.mdx
+++ b/markdown/datahub/use-cases/feature-replication.mdx
@@ -38,7 +38,7 @@ import ThemedImage from '@theme/ThemedImage';
 
     Because of this:
     * Each update contains the entire set of historical records for the feature at that point in time.
-    * To keep data consistent, previously stored records for the specific `id` should be replaced with the newly received history.
+    * To keep data consistent, previously stored records for the specific `id` should be deleted, and the newly received history inserted instead.
     * This method supports data sources that allow corrections or updates to historical feature values, helping to maintain accurate and up-to-date data.
 
     > Replacing old records with the new full history helps avoid duplication and ensures data stays synchronized.


### PR DESCRIPTION
When the Data Integrator creates calculates new features it drops all old values and re-creates the entire feature history. This is done so as not to keep old values that have been filtered away due to a new FtQl definition, or incoming corrections on the data events from the source. We will have to require our customers to do the same if  they whish to have a consistent history of features in their own systems. This commit makes this mechanism very explicit.

This change might require attention from customers who have already implemented a feature sync mechanism without paying attention to this detail. At the time this commit was created no customer has made a full implementation yet. If that is no longer the case upon merging of this commit, further communication with customers is needed.