### PR TITLE
Correct feature names

### DIFF
--- a/markdown/datahub/features/dk-address.mdx
+++ b/markdown/datahub/features/dk-address.mdx
@@ -54,15 +54,15 @@
       _Description_: Code indicating the residence type, e.g., owner-occupied or rental.
       _Example_: `E`
 
-    - **`mainUnit_numberOfToilets`**
+    - **`mainUnit_toilets_count`**
       _Description_: The number of toilets in the unit.
       _Example_: `3`
 
-    - **`mainUnit_numberOfRooms`**
+    - **`mainUnit_rooms_count`**
       _Description_: The number of rooms in the unit.
       _Example_: `4`
 
-    - **`mainUnit_numberOfBathrooms`**
+    - **`mainUnit_bathrooms_count`**
       _Description_: The number of bathrooms in the unit.
       _Example_: `1`
 
@@ -98,37 +98,37 @@
 
     ### 👥 CPR & Resident Features
 
-    - **`residents_youngestResidentBirthDate`**
+    - **`residents_birthDate_youngest`**
       _Description_: Birthdate of the youngest resident.
       _Example_: `1990-01-02`
 
-    - **`residents_oldestResidentBirthDate`**
+    - **`residents_birthDate_oldest`**
       _Description_: Birthdate of the oldest resident.
       _Example_: `1990-01-02`
 
-    - **`residents_numberOfResidents`**
+    - **`residents_count`**
       _Description_: Number of residents living at the address.
       _Example_: `2`
 
     ### 🏘️ Resident-Owned Property Features
 
-    - **`residentsProperties_numberOfPrivateHomes`**
+    - **`residents_ownedPrivateHomes_count`**
       _Description_: Total number of private homes owned by residents.
       _Example_: `2`
 
-    - **`residentsProperties_numberOfVacationHomes`**
+    - **`residents_ownedVacationHomes_count`**
       _Description_: Total number of vacation homes owned by residents.
       _Example_: `1`
 
-    - **`residentsProperties_latestTradePurchasePrice`**
+    - **`residents_propertyTradePurchasePrice_latest`**
       _Description_: Purchase price of most recent property trade by residents.
       _Example_: `1700000`
 
-    - **`residentsProperties_latestTradeClosingDate`**
+    - **`residents_propertyTradeClosingDate_latest`**
       _Description_: Closing date of most recent trade.
       _Example_: `2025-06-01 00:00:00`
 
-    - **`residentsProperties_latestTransferDate`**
+    - **`residents_propertyTransferDate_latest`**
       _Description_: Transfer date of most recent trade.
       _Example_: `2025-06-01 00:00:00`
 


### PR DESCRIPTION
The feature names in the documentation were not aligned with the feature names in API. This commit corrects that.